### PR TITLE
Now revC also reverses RowSideColors

### DIFF
--- a/R/heatmap.2.R
+++ b/R/heatmap.2.R
@@ -405,7 +405,8 @@ heatmap.2 <- function (x,
   ## draw the side bars
   if(!missing(RowSideColors)) {
     par(mar = c(margins[1],0, 0,0.5))
-    image(rbind(1:nr), col = RowSideColors[rowInd], axes = FALSE)
+    iy <- if (revC) nr:1 else 1:nr
+    image(rbind(iy), col = RowSideColors[rowInd], axes = FALSE)
     plot.index <- plot.index + 1
   }
   if(!missing(ColSideColors)) {


### PR DESCRIPTION
If I have added RowSideColors to the heatmap produced by heatmap.2, the option revC correctly flips
the actual heatmap, but not the RowSideColors.

The following code works as expected.

```{r}
library(gplots)
set.seed(124)
n <- 5
m <- matrix(runif(n = n*n), nrow = n)
band <- sample(c("red", "black"), size = n, replace = TRUE)
gplots::heatmap.2(m, trace = "none", density.info = "none",
                  RowSideColors = band)
```

But in the following the RowSideColors are not flipped.

```{r}
gplots::heatmap.2(m, trace = "none", density.info = "none",
                  RowSideColors = band,
                  revC = TRUE)
```

The pull request fixes this issue.