### PR TITLE
Fix: revC works correctly when srtRow is given

### DIFF
--- a/R/heatmap.2.R
+++ b/R/heatmap.2.R
@@ -511,6 +511,7 @@ heatmap.2 <- function (x,
           xpd.orig <- par("xpd")
           par(xpd=NA)
           ypos <- axis(4, iy, labels=rep("", nr), las=2, line= -0.5, tick=0)
+          if (revC) ypos <- rev(ypos)
           text(x=par("usr")[2] + (1.0 + offsetRow) * strwidth("M"),
                y=ypos,
                labels=labRow,


### PR DESCRIPTION
The order of row labels in a heatmap produced by the heatmap.2 function is incorrect (reversed) when both revC and srtRow options are given.

The following works as expected.

```{r}
library(gplots)
set.seed(124)
n <- 5
m <- matrix(runif(n = n*n), nrow = n)
gplots::heatmap.2(m, trace = "none", density.info = "none", revC = TRUE)
```

But in the following the order of row labels is reversed:

```{r}
gplots::heatmap.2(m, trace = "none", density.info = "none",
                  srtRow = 45,
                  revC = TRUE
                  )
```

This is because the axis function in the implementation returns the values in the same order, irrespective of the order
of the input parameter:

```{r}
nr <- 5
iy <- 1:nr
plot(1:4, 1:4)
(axis(4, iy, labels=rep("", nr), las=2, line= -0.5, tick=0))
(axis(4, rev(iy), labels=rep("", nr), las=2, line= -0.5, tick=0))
```

This pull request fixes this problem.